### PR TITLE
Suggest better check intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use VictoRD11\SslCertificationHealthCheck\SslCertificationExpiredCheck;
 use VictoRD11\SslCertificationHealthCheck\SslCertificationValidCheck;
 
 Health::checks([
-    SslCertificationExpiredCheck::new()->url('google.com')->warnWhenSslCertificationExpiringDay(24)->failWhenSslCertificationExpiringDay(14),
+    SslCertificationExpiredCheck::new()->url('google.com')->warnWhenSslCertificationExpiringDay(15)->failWhenSslCertificationExpiringDay(10),
     SslCertificationValidCheck::new()->url('google.com'),
 ]);
 ```


### PR DESCRIPTION
Hi Victor,

For Laravel Forge, your example intervals (24 and 14) are a bit too large, resulting in many warnings. I would suggest that you use 15 and 10 in your example, as these are better fitted for use with Forge, which is one of the main Laravel Deployment platforms.

It's just a small suggestion, feel free to ignore it - no bad feelings :-)

Regards from Brussels,

Nico