### PR TITLE
Properly mark check as failed for expired certificates

### DIFF
--- a/src/SslCertificationExpiredCheck.php
+++ b/src/SslCertificationExpiredCheck.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace VictoRD11\SslCertificationHealthCheck;
 
+use Carbon\Carbon;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Result;
 use Spatie\SslCertificate\SslCertificate;
@@ -60,8 +61,8 @@ class SslCertificationExpiredCheck extends Check
             throw InvalidUrl::make();
         }
 
-        $certificate = SslCertificate::createForHostName($this->url);
-        $daysUntilExpired = $certificate->expirationDate()->diffInDays();
+        $certificate = SslCertificate::createForHostName($this->url, 30, false);
+        $daysUntilExpired = Carbon::now()->diffInDays($certificate->expirationDate(), false);
 
         $result = Result::make()
             ->meta(['days_until_expired' => $daysUntilExpired])

--- a/tests/SslCertificationExpiredCheckTest.php
+++ b/tests/SslCertificationExpiredCheckTest.php
@@ -16,7 +16,7 @@ it('certification is not expired', function () {
     expect($result->status)->toBe(Status::ok());
 });
 
-it('certification is expired with warning', function () {
+it('certification will expire with warning', function () {
     $result = SslCertificationExpiredCheck::new()
         ->url('google.com')
         ->warnWhenSslCertificationExpiringDay(9999)
@@ -25,10 +25,18 @@ it('certification is expired with warning', function () {
     expect($result->status)->toBe(Status::warning());
 });
 
-it('certification is expired with fail', function () {
+it('certification will expire with fail', function () {
     $result = SslCertificationExpiredCheck::new()
         ->url('google.com')
         ->failWhenSslCertificationExpiringDay(9999)
+        ->run();
+
+    expect($result->status)->toBe(Status::failed());
+});
+
+it('certification is expired with fail', function () {
+    $result = SslCertificationExpiredCheck::new()
+        ->url('expired.badssl.com')
         ->run();
 
     expect($result->status)->toBe(Status::failed());


### PR DESCRIPTION
## Description

I fixed two bugs causing the check to crash on expired certificates and marking the check as success for expired certificates.

## Motivation and context

When you check a domain with an expired certificate, the check crashes with the following exception:

> Could not download certificate for host `expired.badssl.com` because Could not connect to `expired.badssl.com:443`.

Based on [the documentation](https://github.com/spatie/ssl-certificate#downloading-invalid-certificate) you should skip certificate verification when downloading expired certificates. Besides that, the logic to see if the certificate has expired is incorrect.

**Current logic (bad)**
```php
echo Carbon::now()->addMonth()->diffInDays(); // 30
echo Carbon::now()->subMonth()->diffInDays(); // 30
```

**New logic (correct)**
```php
echo Carbon::now()->diffInDays(Carbon::now()->addMonth(), false); // 31
echo Carbon::now()->diffInDays(Carbon::now()->subMonth(), false); // -29
```

## How has this been tested?

I added new tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
